### PR TITLE
mask missing in ScaledDotProductAttention call

### DIFF
--- a/deep_dives/transformer_from_scratch.ipynb
+++ b/deep_dives/transformer_from_scratch.ipynb
@@ -449,7 +449,7 @@
     "        V = self.value_tfm(values) # (Batch, Seq, Feature)\n",
     "        log_size(Q, \"queries, keys, vals\")\n",
     "        # compute multiple attention weighted sums\n",
-    "        x = self.attn(Q, K, V)\n",
+    "        x = self.attn(Q, K, V, mask)\n",
     "        return x"
    ]
   },


### PR DESCRIPTION
I'm a newbie in attention mechanisms but I think the `mask` arg is missing when calling the ScaledDotProductAttention block.

Also I noticed in github the right args are passed in the `DecoderBlock` when calling the 2nd `MultiHeadAttention` :
`att = self.attn_head(queries=x, keys=enc_out, values=enc_out, mask=tgt_mask)`

but in the blog, it's still:
`att = self.attn_head(queries=att, keys=x, values=x, mask=tgt_mask)`

It would be nice to fix it too there.

Kudos for your fanstastic blog! Enlightening!